### PR TITLE
feat(qaqc): add QA/QC button

### DIFF
--- a/src/modules/page/page.constants.js
+++ b/src/modules/page/page.constants.js
@@ -194,6 +194,7 @@ export const SECONDARY_PAGES = [
     icon_pressed_src: require('../../assets/icons/QAQC_pressed.png'),
     overview_component: QAQCOverview,
     page_component: QAQCPage,
+    testing: true,
   },
 ];
 

--- a/src/modules/project/datasets/DatasetDetail.js
+++ b/src/modules/project/datasets/DatasetDetail.js
@@ -20,6 +20,11 @@ import SidePanelHeader from '../../main-menu-panel/sidePanel/SidePanelHeader';
 import {setReadOnlyDatasetsIds, updatedDatasetProperties} from '../projects.slice';
 import useProject from '../useProject';
 
+//PADLOCK
+import ActionButton from '../../../shared/ui/buttons/ActionButton';
+import ModalWrapper from '../../../shared/ui/modals/ModalWrapper';
+import {runQAQC} from '../../qaqc/qaqc_funcs';
+
 const DatasetDetail = ({closeDetailView, dataset}) => {
   /* Data Hooks */
 
@@ -28,7 +33,7 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
   const readOnlyDatasetsIds = useSelector(state => state.project.readOnlyDatasetsIds) || [];
   const targetDatasetId = useSelector(state => state.project.targetDatasetId);
 
-  const {initializeDownloadImages} = useDownload();
+  const {initializeDownloadImages, initializeDownload} = useDownload();
   const {destroyDataset} = useProject();
   const [neededImagesCount, refreshNeededImagesCount] = useDatasetNeededImagesCount(dataset);
   const toast = useToast();
@@ -54,6 +59,13 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
   };
 
   const handleDeletePressed = () => setIsDeleteConfirmModalVisible(true);
+
+  //PADLOCK
+  const [isQAQCModalVisible, setIsQAQCModalVisible] = useState(false);
+  const handleQAQCPressed = () => setIsQAQCModalVisible(true);
+  const encodedLogin = useSelector(state => state.user.encoded_login);
+  const {project} = useSelector(state => state.project);
+  const isTestingMode = useSelector(state => state.project.isTestingMode);
 
   const onToggleReadOnly = () => dispatch(setReadOnlyDatasetsIds(dataset.id));
 
@@ -299,6 +311,40 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
     );
   };
 
+  //PADLOCK
+  // QAQC Dataset Button
+  const renderQAQCDatasetButton = () => {
+    if(isTestingMode){
+      return (
+        <View style={{paddingBottom: 10}}>
+          <ActionButton
+            onPress={handleQAQCPressed}
+            title={'Run QAQC'}
+          />
+        </View>
+      );
+    } else return;
+  };
+
+  const renderQAQCModal = () => {
+    return (
+      <ModalWrapper
+        actionTitle={'Run'}
+        cancelTitle={'Cancel'}
+        headerTitle={'QAQC Confirmation'}
+        isVisible={isQAQCModalVisible}
+        onActionPressed={async () => {
+          await runQAQC(dataset, project.id, setIsQAQCModalVisible, encodedLogin, toast);
+          initializeDownload(project, encodedLogin);
+        }}
+        onCancelPress={() => setIsQAQCModalVisible(false)}
+        overlayStyleOverride={{height: 'auto'}}
+      >
+        <Text style={{textAlign:"center"}}>{"Confirm the target dataset:\n"+ datasetName}</Text>
+      </ModalWrapper>
+    );
+  };
+
   /* View */
 
   return (
@@ -314,11 +360,13 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
       {renderSpotsField()}
       {renderImagesField()}
       <LittleSpacer/>
+      {renderQAQCDatasetButton()}
       {renderReadOnlyDatasetButton()}
       <LittleSpacer/>
       {Platform.OS === 'web' && renderDeleteDatasetButton()}
 
-      {/* Child Modal */}
+      {/* Child Modal */}      
+      {isQAQCModalVisible && renderQAQCModal()}
       {isDeleteConfirmModalVisible && renderDeleteConfirmationModal()}
     </>
   );

--- a/src/modules/qaqc/qaqc_funcs.js
+++ b/src/modules/qaqc/qaqc_funcs.js
@@ -1,0 +1,85 @@
+import {QAQC_PATHS} from "../../services/network/urls.constants";
+import {getRequest} from "../../services/network/serverRequestHelpers";
+
+const basicAuth = (token = encoded_login) => ({type: 'basic', token});
+
+export const startQAQC = async (dataset, projectID, encodedLogin, toast) => {
+    console.log("startQAQC()");
+    if (!dataset.id) {
+        console.error('Dataset ID is missing');
+        alert('Error: Project ID is missing');
+        return;
+    }
+
+    if (!encodedLogin) {
+        console.error('User credentials are missing');
+        alert('Error: User credentials are missing');
+        return;
+    }
+
+    
+    toast_id = toast.show(
+    `Started QAQC process for ${dataset.name}, please wait until download...`,
+    {
+        type: 'normal',
+        animationType: 'slide-in',
+        duration: 20000,
+        placement: 'top',
+    });
+        
+    try{
+        // Python script parameters
+        const params = new URLSearchParams({
+            'action': 'completeness',
+            'plainreq': 'true',
+            'doAnnotate': 'true',
+            'pid': projectID,
+            'dsid': dataset.id,
+        });
+
+        // Send the request
+        const response = await getRequest(`${QAQC_PATHS.URL}/api.php?${params.toString()}`, basicAuth(encodedLogin), {responseType: 'document'});
+
+        // Block until response
+        await response.text();
+        console.log("response.text() passed")
+
+        if (!response.ok) {
+            toast.hide(toast_id);
+            throw new Error(`HTTP error. status: ${response.status}`);
+        }
+
+        // I think we want to force the user to download QAQC notes to avoid desync with local datasets
+        // This just stalls for 3 seconds, the initializeDownload call is in DatasetDetails
+        for (let iter = 3; iter > 0; iter--){
+            toast.update(toast_id,
+                `Downloading ${dataset.name} in ${iter} seconds.`,
+                {type: 'warning'}
+            );
+            await new Promise(r => setTimeout(r, 1000));
+        };
+
+        toast.hide(toast_id);
+
+        return response;
+
+    } catch(err){
+        console.error(`startQAQC(): ${err}`)
+        throw(err)
+    }
+
+};
+
+export const runQAQC = async (dataset, currentProjectId, setModalVisible, encodedLogin, toast) => {
+    console.log("runQAQC()")
+    setModalVisible(false);
+    if (dataset && dataset.id) {
+        try {
+            return await startQAQC(dataset, currentProjectId, encodedLogin, toast);
+        } catch (err) {
+            console.error(`runQAQC(): ${err}`);
+            alert(`runQAQC Error: ${err.message}`);
+        }
+    }
+    else console.error('Target dataset or id is undefined!');
+  };

--- a/src/services/network/urls.constants.js
+++ b/src/services/network/urls.constants.js
@@ -80,3 +80,7 @@ export const SUPPORT_PATHS = {
   GITHUB: 'https://github.com/StraboSpot/StraboField/issues/new/choose',
   EMAIL: 'mailto: strabospot@gmail.com?subject=StraboSpot2%20Issue',
 };
+
+export const QAQC_PATHS = {
+  URL:  'https://strabo.analysis.cool',
+};


### PR DESCRIPTION
## What?
Added QAQC button in testing mode and start the dataset download after QAQC API returns a response
## Why?
Allow QAQC to be initiated from StraboField
## How?
Added [button](https://github.com/StraboSpot/StraboField/pull/895/changes#diff-2cde7a2208a0672fd73bc3cad72df0363c15b15e50b13a7b0a7b60db7509e786R316) and [modal](https://github.com/StraboSpot/StraboField/pull/895/changes#diff-2cde7a2208a0672fd73bc3cad72df0363c15b15e50b13a7b0a7b60db7509e786R329) to DatasetDetails
Awaiting response text in [qaqc_funcs](https://github.com/StraboSpot/StraboField/pull/895/changes#diff-a5b4894a14fc0281a246ad20bdd4fb9b0b3a7cdd6cbee5e5a118debd9892d245R47) for calling initializeDownload.
## Testing?
Still need to do a native device test, will update pull request afterwards.