### PR TITLE
feat(qaqc): upload project before QAQC

### DIFF
--- a/src/modules/project/datasets/DatasetDetail.js
+++ b/src/modules/project/datasets/DatasetDetail.js
@@ -24,6 +24,7 @@ import useProject from '../useProject';
 import ActionButton from '../../../shared/ui/buttons/ActionButton';
 import ModalWrapper from '../../../shared/ui/modals/ModalWrapper';
 import {runQAQC} from '../../qaqc/qaqc_funcs';
+import useUpload from '../../../services/files/useUpload';
 
 const DatasetDetail = ({closeDetailView, dataset}) => {
   /* Data Hooks */
@@ -66,6 +67,7 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
   const encodedLogin = useSelector(state => state.user.encoded_login);
   const {project} = useSelector(state => state.project);
   const isTestingMode = useSelector(state => state.project.isTestingMode);
+  const {initializeUpload} = useUpload();
 
   const onToggleReadOnly = () => dispatch(setReadOnlyDatasetsIds(dataset.id));
 
@@ -329,18 +331,36 @@ const DatasetDetail = ({closeDetailView, dataset}) => {
   const renderQAQCModal = () => {
     return (
       <ModalWrapper
-        actionTitle={'Run'}
+        actionTitle={'Upload and Run'}
         cancelTitle={'Cancel'}
         headerTitle={'QAQC Confirmation'}
         isVisible={isQAQCModalVisible}
         onActionPressed={async () => {
-          await runQAQC(dataset, project.id, setIsQAQCModalVisible, encodedLogin, toast);
-          initializeDownload(project, encodedLogin);
+          setIsQAQCModalVisible(false);
+          toast_id = toast.show(
+          `Uploading project: ${project.description.project_name}`,
+          {
+              type: 'warning',
+              animationType: 'slide-in',
+              duration: 20000,
+              placement: 'top',
+          });
+          uploadStatus = await initializeUpload();
+          if(uploadStatus.datasets == "uploaded"){
+            try{
+              await runQAQC(dataset, project.id, encodedLogin, toast, toast_id);
+              initializeDownload(project, encodedLogin);
+            } catch(err){
+              toast.update(toast_id, `Failed to run QAQC.`, {type:'error', duration: 5000,});
+            }
+          } else{
+            toast.update(toast_id, `Failed to upload datasets.`, {type: 'error', duration: 5000,});
+          }
         }}
         onCancelPress={() => setIsQAQCModalVisible(false)}
         overlayStyleOverride={{height: 'auto'}}
       >
-        <Text style={{textAlign:"center"}}>{"Confirm the target dataset:\n"+ datasetName}</Text>
+        <Text style={{textAlign:"center"}}>{"Must upload any changes on device first"}</Text>
       </ModalWrapper>
     );
   };

--- a/src/modules/qaqc/qaqc_funcs.js
+++ b/src/modules/qaqc/qaqc_funcs.js
@@ -3,27 +3,26 @@ import {getRequest} from "../../services/network/serverRequestHelpers";
 
 const basicAuth = (token = encoded_login) => ({type: 'basic', token});
 
-export const startQAQC = async (dataset, projectID, encodedLogin, toast) => {
+export const startQAQC = async (dataset, projectID, encodedLogin, toast, toast_id) => {
+    // Check for dataset id and encoded login
     console.log("startQAQC()");
     if (!dataset.id) {
         console.error('Dataset ID is missing');
-        alert('Error: Project ID is missing');
-        return;
+        throw new Error('Project ID is missing');
     }
 
     if (!encodedLogin) {
         console.error('User credentials are missing');
-        alert('Error: User credentials are missing');
-        return;
+        throw new Error('User credentials are missing');
     }
 
-    
-    toast_id = toast.show(
+    // Update toast to show dataset name
+    toast.update(toast_id,
     `Started QAQC process for ${dataset.name}, please wait until download...`,
     {
         type: 'normal',
         animationType: 'slide-in',
-        duration: 20000,
+        duration: 120000,
         placement: 'top',
     });
         
@@ -42,8 +41,6 @@ export const startQAQC = async (dataset, projectID, encodedLogin, toast) => {
 
         // Block until response
         await response.text();
-        console.log("response.text() passed")
-
         if (!response.ok) {
             toast.hide(toast_id);
             throw new Error(`HTTP error. status: ${response.status}`);
@@ -53,7 +50,7 @@ export const startQAQC = async (dataset, projectID, encodedLogin, toast) => {
         // This just stalls for 3 seconds, the initializeDownload call is in DatasetDetails
         for (let iter = 3; iter > 0; iter--){
             toast.update(toast_id,
-                `Downloading ${dataset.name} in ${iter} seconds.`,
+                `Downloading QAQC notes in ${iter} seconds.`,
                 {type: 'warning'}
             );
             await new Promise(r => setTimeout(r, 1000));
@@ -64,21 +61,18 @@ export const startQAQC = async (dataset, projectID, encodedLogin, toast) => {
         return response;
 
     } catch(err){
-        console.error(`startQAQC(): ${err}`)
         throw(err)
     }
 
 };
 
-export const runQAQC = async (dataset, currentProjectId, setModalVisible, encodedLogin, toast) => {
+export const runQAQC = async (dataset, currentProjectId, encodedLogin, toast, toast_id) => {
     console.log("runQAQC()")
-    setModalVisible(false);
     if (dataset && dataset.id) {
         try {
-            return await startQAQC(dataset, currentProjectId, encodedLogin, toast);
+            return await startQAQC(dataset, currentProjectId, encodedLogin, toast, toast_id);
         } catch (err) {
-            console.error(`runQAQC(): ${err}`);
-            alert(`runQAQC Error: ${err.message}`);
+            throw(err);
         }
     }
     else console.error('Target dataset or id is undefined!');


### PR DESCRIPTION
## What?
Move QAQC to be behind Testing Mode, Upload local project before beginning QAQC, and handle error responses
## Why?
Avoid overwriting local changes with QAQC notes
## How?
Added [initializeUpload](https://github.com/BaileySri/StraboField/commit/3d7404e887f52ac0619bfd1d66cf748cd1c3269f#diff-2cde7a2208a0672fd73bc3cad72df0363c15b15e50b13a7b0a7b60db7509e786R352) call before running QAQC
## Testing?
Need to test on (maybe) ipad device? Need to reach out to Doug about a native testing device